### PR TITLE
replace tabs in log line by four spaces

### DIFF
--- a/log_record.go
+++ b/log_record.go
@@ -264,6 +264,7 @@ func ParseAsRecord(cfg config.Configuration, options Options, lineNo int, rawLin
 	if err := json.Unmarshal([]byte(line), &allFields); err != nil {
 		log.Printf("parse round 1 failed: line %d: <%s>\n\treason %v\n", lineNo, line, errors.Wrap(err, ""))
 		line = strings.ReplaceAll(line, "\\\"", "\"")
+		line = strings.ReplaceAll(line, "\t", "    ")
 		if err := json.Unmarshal([]byte(line), &allFields); err != nil {
 			log.Printf("parse round 2 failed: line %d: <%s>\n\treason %v\n", lineNo, line, errors.Wrap(err, ""))
 			return r


### PR DESCRIPTION
replace tabs in log line by four spaces
e.g. Apache Camel writes log containing tabs
The unmarshaling fails and the log line gets 'marked' as invalid, but it isn't.

It maybe useful to create a config parameter for the amount of spaces. Feel free to do so.