### PR TITLE
tabularize log output

### DIFF
--- a/static_files/DefaultConfiguration.yml
+++ b/static_files/DefaultConfiguration.yml
@@ -27,6 +27,7 @@ fields:
       color: FgDefault
   level: # 'level' field is a hard-coded field used for level filter as well, so don't rename it
          # And, it must be an enum.
+    print-format: "%-5.5s" #
     alias: "level, @level, severity, @severity"
     case-sensitive: false
     enums:

--- a/util/colors.go
+++ b/util/colors.go
@@ -149,3 +149,8 @@ func (i Color) MarshalYAML() (interface{}, error) {
 func (i Color) Sprint(a interface{}) string {
 	return i.style.Sprint(a)
 }
+
+// Sprintf is alias of the 'Render'
+func (i Color) Sprintf(format string, a ...interface{}) string {
+	return i.style.Sprintf(format, a...)
+}


### PR DESCRIPTION
added two config parameters width and fixed to tabularize the output
 
* width:  defines the min. width of a field <br/> a negative value will left-align the field value, a positive value will right-align<br/>  widths between -4 and 4 will be forced to -4 respectively 4 (why see fixed)<br/> a value of 0 will be treated as no specified width, so nothing changes 
* fixed: defines that the value defined by width is also the max width of the column<br/> if the content of the field has more chars than the width, the content gets shortened to width - 3 chars and post-fixed by three dots to mark the continuation

Sample Output:
```
1      --~~BANNER~~--
2      2020.10-20T00:01:01.001 | TRACE |    1234-5678-90 | localhost:io.FooBar:thread-1                                 | Lorem ipsum
3      2020.10-20T00:01:01.001 | TRACE |    1234-5678-90 | localhost:org.somepackage.subPackage.FinalClass.finalMeth... | Lorem ipsum
4      2020.10-20T00:01:01.002 | FINE  |                 | localhost:org.somepackage.subPackage.FinalClass2.finalMet... | Lorem ipsum
5      2020.10-20T00:01:01.003 | DEBUG |                 | localhost:org.otherpackage.FinalClass.finalMethode:thread-2  | Lorem ipsum
6      2020.10-20T00:01:01.004 | INFO  |    1234-5678-90 | localhost:org.somepackage.subPackage.subPackage.FinalClas... | Lorem ipsum
7      2020.10-20T00:01:01.005 | WARN  |  1234-5678-90AB | localhost:org.somepackage.FinalClass.finalMethode:thread-1   | Lorem ipsum
8      2020.10-20T00:01:01.006 | ERROR |    1234-5678-90 | localhost:org.somepackage.FinalClass.finalMethode:thread-1   | Lorem ipsum
9      2020.10-20T00:01:01.007 | FATAL |    1234-5678-90 | localhost:org.somepackage.FinalClass.finalMethode:thread-1   | Lorem ipsum
```
